### PR TITLE
Hide APIs behind features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ license-file = "LICENSE"
 keywords = ["op", "banking", "http", "rest"]
 categories = ["api-bindings"]
 
+[features]
+default = ["accounts"]
+accounts = ["chrono"]
+
 [dependencies]
 log = "0.4.11"
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.10.8", features = ["json"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros"] }

--- a/examples/accounts.rs
+++ b/examples/accounts.rs
@@ -11,15 +11,21 @@ use op_api_sdk::client::Client;
 /// ```bash
 /// cargo run --example accounts <API_KEY>
 /// ```
+
+#[allow(dead_code)]
+#[cfg(feature = "accounts")]
 use op_api_sdk::model::accounts::{
     AccountList, TransactionList, TransactionParams, TransactionParty,
 };
+#[allow(unused_imports)]
 use op_api_sdk::options::Options;
+#[allow(unused_imports)]
 use std::env;
 
 const NONE_STRING: &str = "None";
 
 /// Prints transaction party information.
+#[cfg(feature = "accounts")]
 fn print_transaction_party(party: Option<TransactionParty>) {
     match party {
         Some(p) => {
@@ -34,6 +40,7 @@ fn print_transaction_party(party: Option<TransactionParty>) {
 }
 
 /// Prints transactions from transaction list.
+#[cfg(feature = "accounts")]
 fn print_transactions_with_details(transactions: TransactionList) {
     if transactions.transactions.is_empty() {
         println!("  No transactions found");
@@ -76,6 +83,7 @@ fn print_transactions_with_details(transactions: TransactionList) {
 /// each account using the Accounts client. This function must be async
 /// as we are calling another async function for fetching the transactions
 /// for the accounts.
+#[cfg(feature = "accounts")]
 async fn print_accounts_with_details(client: &Client, accounts: AccountList) {
     println!("Found {} accounts:", accounts.accounts.len());
     for acc in accounts.accounts {
@@ -112,6 +120,7 @@ async fn print_accounts_with_details(client: &Client, accounts: AccountList) {
 /// Example of getting accounts for the user. Uses OP API sandbox.
 /// API key must be given as command line argument.
 #[tokio::main]
+#[cfg(feature = "accounts")]
 async fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() <= 1 {
@@ -131,4 +140,10 @@ async fn main() {
             println!("Failed to get accounts: {}", e);
         }
     };
+}
+
+#[tokio::main]
+#[cfg(not(feature = "accounts"))]
+async fn main() {
+    println!("No accounts feature enabled, please enable it to run this example!");
 }

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains internal clients for different APIs
 //! defined in [OP API](https://op-developer.fi/docs).
 
+#[cfg(feature = "accounts")]
 pub mod accounts;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,9 @@
 //! This module contains Client to communicate with different APIs
 //! defined in [OP API](https://op-developer.fi/docs).
 
+#[cfg(feature = "accounts")]
 use crate::apis::accounts::AccountsApi;
+#[cfg(feature = "accounts")]
 use crate::model::accounts::*;
 use crate::options::Options;
 use std::error::Error;
@@ -9,6 +11,7 @@ use std::sync::Arc;
 
 pub struct Client {
     options: Arc<Options>,
+    #[cfg(feature = "accounts")]
     accounts_api: AccountsApi,
 }
 
@@ -20,6 +23,7 @@ impl Client {
     pub fn new(options: Arc<Options>) -> Client {
         Client {
             options: options.clone(),
+            #[cfg(feature = "accounts")]
             accounts_api: AccountsApi::new(options),
         }
     }
@@ -36,17 +40,20 @@ impl Client {
     }
 
     /// Gets all accounts from the API and returns list of them.
+    #[cfg(feature = "accounts")]
     pub async fn accounts(&self) -> Result<AccountList, Box<dyn Error>> {
         self.accounts_api.accounts().await
     }
 
     /// Gets single account from the API based on accountId.
+    #[cfg(feature = "accounts")]
     pub async fn account(&self, account_id: String) -> Result<Account, Box<dyn Error>> {
         self.accounts_api.account(account_id).await
     }
 
     /// Gets all transactions for a single account with account id
     /// with optional parameters for filtering the results.
+    #[cfg(feature = "accounts")]
     pub async fn transactions(
         &self,
         account_id: String,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains data structures for different APIs
 //! defined in [OP API](https://op-developer.fi/docs).
 
+#[cfg(feature = "accounts")]
 pub mod accounts;

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg(feature = "accounts")]
 mod accounts_tests {
     use op_api_sdk::client::Client;
     use op_api_sdk::model::accounts::*;


### PR DESCRIPTION
This can be useful when user does not need all functionality of the
library. By default, all features should be enabled also for further API
implementations.

This closes #3 